### PR TITLE
Use lookarounds for domain matching

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -10,7 +10,8 @@ def normalize_text(s: str) -> str:
 def contains_any(text: str, needles: Iterable[str]) -> bool:
     """
     Check if text contains any of the IoCs with improved matching.
-    Uses word boundaries for domains and exact matching for IPs to reduce false positives.
+    Uses negative lookarounds for domains and exact matching for IPs to reduce false
+    positives.
     """
     if not text or not needles:
         return False
@@ -25,10 +26,9 @@ def contains_any(text: str, needles: Iterable[str]) -> bool:
         if _looks_like_ip(needle):
             if re.search(rf"\b{re.escape(needle)}\b", t):
                 return True
-        # For domains, use word boundaries but allow subdomain matching
+        # For domains, ensure the match is not part of a larger token
         else:
-            # Match domain.com or subdomain.domain.com
-            pattern = rf"\b{re.escape(needle)}\b"
+            pattern = rf"(?<![\w.-]){re.escape(needle)}(?![\w.-])"
             if re.search(pattern, t):
                 return True
     return False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+# Ensure src directory is on sys.path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from utils import contains_any
+
+
+def test_contains_any_matches_exact_domain():
+    assert contains_any("domain.com", ["domain.com"]) is True
+
+
+def test_contains_any_ignores_similar_domains():
+    needles = ["domain.com"]
+    assert contains_any("sub.domain.com", needles) is False
+    assert contains_any("domain.com.bad", needles) is False
+    assert contains_any("notdomain.com", needles) is False


### PR DESCRIPTION
## Summary
- avoid partial domain matches by using negative lookarounds
- add regression tests for tricky domains
