### PR TITLE
Add context manager support to M365Client

### DIFF
--- a/src/m365_client.py
+++ b/src/m365_client.py
@@ -138,3 +138,13 @@ class M365Client:
                 resp.raise_for_status()
         except requests.RequestException as e:
             raise RuntimeError(f"Failed to send mail to {to}: {e}")
+
+    def close(self) -> None:
+        """Close the underlying HTTP session."""
+        self._session.close()
+
+    def __enter__(self) -> "M365Client":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()

--- a/src/main.py
+++ b/src/main.py
@@ -165,22 +165,22 @@ def main():
 
     try:
         cfg = load_config(Path(args.config))
-        client = M365Client(
+        with M365Client(
             tenant_id=cfg["tenant_id"],
             client_id=cfg["client_id"],
             client_secret=cfg["client_secret"],
             scope=cfg.get("scope", "https://graph.microsoft.com/.default"),
             graph_base=cfg.get("graph_base", "https://graph.microsoft.com/v1.0"),
-        )
+        ) as client:
 
-        scan_and_tag(
-            client=client,
-            user=args.user,
-            top=args.top,
-            category=args.category.strip(),
-            ensure_category=args.ensure_category,
-            summary_to=args.summary_to,
-        )
+            scan_and_tag(
+                client=client,
+                user=args.user,
+                top=args.top,
+                category=args.category.strip(),
+                ensure_category=args.ensure_category,
+                summary_to=args.summary_to,
+            )
     except KeyboardInterrupt:
         print("\nOperation cancelled by user")
         sys.exit(1)


### PR DESCRIPTION
## Summary
- implement `close`, `__enter__`, and `__exit__` in `M365Client` for proper session cleanup
- use context manager when invoking `M365Client` in `main`
